### PR TITLE
Fix some bugs with rhyme detection

### DIFF
--- a/poetrytools/poetics.py
+++ b/poetrytools/poetics.py
@@ -51,7 +51,7 @@ def get_syllables(word):
     try:
         return CMU[word.lower()]
     except KeyError:
-        return False
+        return [[]]
 
 
 def stress(word):
@@ -94,19 +94,15 @@ def num_vowels(syllables):
     return len([syl for syl in syllables if any(char.isdigit() for char in syl)])
 
 
-def get_vowel_index(syllables, n):
-    """Given the rhyme level n and a syllable list, count back within the syllable list to find the
-    nth vowel."""
+def get_nth_last_vowel(phones, n):
+    """Given the rhyme level n and a syllable (phone) list, count backward within the list to find the
+    nth vowel. Return the (negative) index where it can be located."""
     vowel_count = 0
-    nth_vowel_index = 0
-    for i in range(0, len(syllables), 1):
-        syl = syllables[-i]
-        if any(char.isdigit() for char in syl):
+    for i in range(1, len(phones)+1):
+        if any(ch.isdigit() for ch in phones[-i]):
             vowel_count += 1
             if vowel_count == n:
-                nth_vowel_index = i
-                break
-    return nth_vowel_index
+                return -i
 
 
 def rhymes(word1, word2, level=2):
@@ -130,11 +126,11 @@ def rhymes(word1, word2, level=2):
         # If word only has a single vowel (i.e. 'stew'), then we reduce this to 1 otherwise we won't find a monosyllabic rhyme
         if num_vowels(syllables) < level:
             level = num_vowels(syllables)
-        vowel_idx = get_vowel_index(syllables, level)  # Default number of syllables to check back from
+        vowel_idx = get_nth_last_vowel(syllables, level)  # Default number of syllables to check back from
 
         for syllables2 in pronunciations2:
             syllables2 = replace_syllables(syllables2)
-            if syllables[-vowel_idx:] == syllables2[-vowel_idx:]:
+            if syllables[vowel_idx:] == syllables2[vowel_idx:]:
                 return True
 
     return False

--- a/poetrytools/poetics.py
+++ b/poetrytools/poetics.py
@@ -99,7 +99,7 @@ def get_nth_last_vowel(phones, n):
     nth vowel. Return the (negative) index where it can be located."""
     vowel_count = 0
     for i in range(1, len(phones)+1):
-        if any(ch.isdigit() for ch in phones[-i]):
+        if phones[-i][-1].isdigit():
             vowel_count += 1
             if vowel_count == n:
                 return -i

--- a/poetrytools/poetics.py
+++ b/poetrytools/poetics.py
@@ -94,6 +94,21 @@ def num_vowels(syllables):
     return len([syl for syl in syllables if any(char.isdigit() for char in syl)])
 
 
+def get_vowel_index(syllables, n):
+    """Given the rhyme level n and a syllable list, count back within the syllable list to find the
+    nth vowel."""
+    vowel_count = 0
+    nth_vowel_index = 0
+    for i in range(0, len(syllables), 1):
+        syl = syllables[-i]
+        if any(char.isdigit() for char in syl):
+            vowel_count += 1
+            if vowel_count == n:
+                nth_vowel_index = i
+                break
+    return nth_vowel_index
+
+
 def rhymes(word1, word2, level=2):
     """
     For each word, get a list of various syllabic pronunications. Then check whether the last level number of syllables is pronounced the same. If so, the words probably rhyme
@@ -112,14 +127,14 @@ def rhymes(word1, word2, level=2):
 
     for syllables in pronunciations:
         syllables = replace_syllables(syllables)
-        syls = level # Default number of syllables to check back from
         # If word only has a single vowel (i.e. 'stew'), then we reduce this to 1 otherwise we won't find a monosyllabic rhyme
-        if num_vowels(syllables) == 1:
-            syls = 1
+        if num_vowels(syllables) < level:
+            level = num_vowels(syllables)
+        vowel_idx = get_vowel_index(syllables, level)  # Default number of syllables to check back from
 
         for syllables2 in pronunciations2:
             syllables2 = replace_syllables(syllables2)
-            if syllables[-syls:] == syllables2[-syls:]:
+            if syllables[-vowel_idx:] == syllables2[-vowel_idx:]:
                 return True
 
     return False

--- a/poetrytools/tests/test_poetics.py
+++ b/poetrytools/tests/test_poetics.py
@@ -54,16 +54,31 @@ class TestPoems(unittest.TestCase):
         self.assertTrue(poetrytools.rhymes(
             'junction', 'function', 2))
 
+    def test_initial_rhyme(self):
+        self.assertTrue(poetrytools.rhymes(
+            'old', 'cold', 1))
+
     def test_vowel_index(self):
-        self.assertEqual(poetrytools.get_vowel_index(
+        self.assertEqual(poetrytools.get_nth_last_vowel(
             poetrytools.get_syllables('border')[0], 2),
-            4
+            -2
+        )
+
+    def test_vowel_index_tricky(self):
+        self.assertEqual(poetrytools.get_nth_last_vowel(
+            poetrytools.get_syllables('ratio')[0], 2),
+            -2
+        )
+
+    def test_vowel_index_nonexistent(self):
+        self.assertIsNone(poetrytools.get_nth_last_vowel(
+            poetrytools.get_syllables('2000')[0], 2)
         )
 
     def test_vowel_index(self):
-        self.assertEqual(poetrytools.get_vowel_index(
+        self.assertEqual(poetrytools.get_nth_last_vowel(
             poetrytools.get_syllables('beautiful')[0], 3),
-            6
+            -6
         )
 
     def test_bad_rhyme_1_syll(self):

--- a/poetrytools/tests/test_poetics.py
+++ b/poetrytools/tests/test_poetics.py
@@ -40,6 +40,39 @@ class TestPoems(unittest.TestCase):
         self.assertTrue(poetrytools.guess_form(
             self.open_poem('rondeau.txt')) == 'rondeau')
 
+    def test_num_vowels(self):
+        self.assertEqual(poetrytools.num_vowels(
+            poetrytools.get_syllables('create')[0]),
+            2
+        )
+
+    def test_rhyme_level_1(self):
+        self.assertTrue(poetrytools.rhymes(
+            'berate', 'create', 1))
+
+    def test_rhyme_level_2(self):
+        self.assertTrue(poetrytools.rhymes(
+            'junction', 'function', 2))
+
+    def test_vowel_index(self):
+        self.assertEqual(poetrytools.get_vowel_index(
+            poetrytools.get_syllables('border')[0], 2),
+            4
+        )
+
+    def test_vowel_index(self):
+        self.assertEqual(poetrytools.get_vowel_index(
+            poetrytools.get_syllables('beautiful')[0], 3),
+            6
+        )
+
+    def test_bad_rhyme_1_syll(self):
+        self.assertFalse(poetrytools.rhymes(
+            'prep', 'stop'))
+
+    def test_bad_rhyme_2_syll(self):
+        self.assertFalse(poetrytools.rhymes(
+            'conduct', 'abstract'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='poetrytools',
-      version='0.2',
+      version='0.3',
       description='Analyse rhyme scheme, metre and form of poems',
       long_description=readme(),
       author='L Tennant',


### PR DESCRIPTION
* `Level` is used to force `n` last syllables to rhyme, but the
`syllables` list is sounds from the CMU dict, not syllables.
* Instead, count back `n` vowels, and use the index to check
the last `n` syllables.
* If the `level` is less than the number of vowel sounds,
set `level` to be the number of vowel sounds (which should always
equal the number of syllables)
* Add a bunch of tests